### PR TITLE
always create a new venv on startup

### DIFF
--- a/client/ayon_comfyui/addon.py
+++ b/client/ayon_comfyui/addon.py
@@ -1,10 +1,10 @@
-import os
+from pathlib import Path
 from ayon_core.addon import AYONAddon, IPluginPaths, IHostAddon
 
 from .version import __version__
 
 
-ADDON_ROOT = os.path.dirname(os.path.abspath(__file__))
+ADDON_ROOT = Path(__file__).parent.resolve()
 ADDON_NAME = "comfyui"
 ADDON_LABEL = "ComfyUI"
 ADDON_VERSION = __version__
@@ -19,7 +19,15 @@ class ComfyUIAddon(AYONAddon, IPluginPaths, IHostAddon):
         """Initialization of module."""
         self.enabled = True
 
+    def get_launch_hook_paths(self, app):
+        self.log.debug(f"{app = }")
+        return [
+            (ADDON_ROOT / "hooks").as_posix(),
+        ]
+
     def get_plugin_paths(self):
         return {
-            "actions": [os.path.join(ADDON_ROOT, "plugins", "actions")],
+            "actions": [
+                (ADDON_ROOT / "plugins" / "actions").as_posix(),
+            ],
         }

--- a/client/ayon_comfyui/plugins/actions/launch_comfyui.ps1
+++ b/client/ayon_comfyui/plugins/actions/launch_comfyui.ps1
@@ -10,10 +10,8 @@ if (-not (Get-Command "uv" -ErrorAction SilentlyContinue)) {
     $env:Path += ";$env:USERPROFILE\.cargo\bin"
 }
 
-# Check for local venv
-if (-not (Test-Path .\venv)) {
-    uv venv
-}
+# create local venv
+uv venv --allow-existing
 .venv\Scripts\activate
 
 # Install requirements

--- a/client/ayon_comfyui/plugins/actions/open_comfui.py
+++ b/client/ayon_comfyui/plugins/actions/open_comfui.py
@@ -29,56 +29,77 @@ class OpenComfyUI(LauncherAction):
         return True
 
     def process(self, selection, **kwargs):
+        self.pre_process(selection)
+        self.clone_repositories()
+        self.run_server()
+
+    def pre_process(self, selection):
         # get project anatomy
         anatomy = Anatomy(project_name=selection.project_name)
         tmpl_data = get_template_data(selection.project_entity)
         tmpl_data.update({"root": anatomy.roots})
 
-        addon_settings = ayon_api.get_addon_project_settings(
+        self.addon_settings = ayon_api.get_addon_project_settings(
             ADDON_NAME, ADDON_VERSION, tmpl_data["project"]["name"]
         )
 
-        # clone comfyui
-        comfy_root_tmpl = StringTemplate(addon_settings["repo"]["root"])
-        comfy_root = Path(comfy_root_tmpl.format_strict(tmpl_data))
-        self._git_clone(
-            url=addon_settings["repo"]["url"],
-            root=comfy_root,
-            tag=addon_settings["repo"]["tag"],
+        comfy_root_tmpl = StringTemplate(self.addon_settings["repo"]["root"])
+        self.comfy_root = Path(comfy_root_tmpl.format_strict(tmpl_data))
+
+        self.plugins = self.addon_settings.get("plugins", [])
+
+    def clone_repositories(self):
+        def git_clone(url: str, dest: Path, tag: str = "") -> git.Repo:
+            if not dest.exists():
+                log.info(f"Cloning {url} to {dest}")
+                repo = git.Repo.clone_from(url, dest)
+            else:
+                repo = git.Repo(dest)
+
+            if tag:
+                log.info(f"Checking out tag {tag} for {repo}")
+                repo.git.checkout(tag)
+            return repo
+
+        git_clone(
+            url=self.addon_settings["repo"]["url"],
+            dest=self.comfy_root,
+            tag=self.addon_settings["repo"]["tag"],
         )
 
         # clone custom nodes
-        plugins = addon_settings.get("plugins", [])
-        for plugin in plugins:
+        for plugin in self.plugins:
             plugin_name = Path(plugin["url"]).name[:-4]
-            plugin_root = comfy_root / "custom_nodes" / plugin_name
+            plugin_root = self.comfy_root / "custom_nodes" / plugin_name
             plugin.update({"root": plugin_root})
-            self._git_clone(
+            git_clone(
                 url=plugin["url"],
-                root=plugin_root,
+                dest=plugin_root,
                 tag=plugin["tag"],
             )
 
+    def copy_checkpoints(self):
         # copy checkpoints
-        if checkpoints_dir := addon_settings.get("checkpoints_dir"):
-            comfy_checkpoints_dir = comfy_root / "models" / "checkpoints"
+        if checkpoints_dir := self.addon_settings.get("checkpoints_dir"):
+            comfy_checkpoints_dir = self.comfy_root / "models" / "checkpoints"
             for cp in Path(checkpoints_dir).iterdir():
                 checkpoint_dest = comfy_checkpoints_dir / cp.name
                 if not checkpoint_dest.exists():
                     log.info(f"Copying {cp} to {comfy_checkpoints_dir}")
                     shutil.copyfile(cp, checkpoint_dest)
 
+    def run_server(self):
         # run the server in a new terminal session
         launch_script = Path(__file__).parent / "launch_comfyui.ps1"
         _cmd: list = [launch_script.as_posix()]
 
         launch_args = []
-        if addon_settings.get("use_cpu"):
+        if self.addon_settings.get("use_cpu"):
             log.info("Launching ComfyUI with CPU only.")
             launch_args.append("-useCpu")
-        if plugins:
+        if self.plugins:
             launch_args.append("-plugins")
-            plugin_names = [plugin["root"].name for plugin in plugins]
+            plugin_names = [plugin["root"].name for plugin in self.plugins]
             launch_args.extend(list(plugin_names))
 
         _cmd.extend(launch_args)
@@ -95,17 +116,5 @@ class OpenComfyUI(LauncherAction):
             text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=comfy_root,
+            cwd=self.comfy_root,
         )
-
-    def _git_clone(self, url: str, root: Path, tag: str = "") -> git.Repo:
-        if not root.exists():
-            log.info(f"Cloning {url} to {root}")
-            repo = git.Repo.clone_from(url, root)
-        else:
-            repo = git.Repo(root)
-
-        if tag:
-            log.info(f"Checking out tag {tag} for {repo}")
-            repo.git.checkout(tag)
-        return repo


### PR DESCRIPTION
## Description
When interrupting the launch process of ComfyUI it can happen that the venv gets mangled. This PR tries to account for that by recreating a new identical venv on launch with `uv venv --allow-existing`